### PR TITLE
[Feature] Add masters as referers for drag and drop

### DIFF
--- a/lib/lib/Timeline.js
+++ b/lib/lib/Timeline.js
@@ -136,11 +136,12 @@ function (_Component) {
       var width = containerWidth - props.sidebarWidth - props.rightSidebarWidth;
       var canvasWidth = (0, _calendar.getCanvasWidth)(width);
 
-      var _stackTimelineItems = (0, _calendar.stackTimelineItems)(props.items, props.groups, canvasWidth, _this.state.canvasTimeStart, _this.state.canvasTimeEnd, props.keys, props.lineHeight, props.itemHeightRatio, props.stackItems, _this.state.draggingItem, _this.state.resizingItem, _this.state.dragTime, _this.state.resizingEdge, _this.state.resizeTime, _this.state.newGroupOrder),
+      var _stackTimelineItems = (0, _calendar.stackTimelineItems)(props.items, props.groups, canvasWidth, _this.state.canvasTimeStart, _this.state.canvasTimeEnd, props.keys, props.lineHeight, props.itemHeightRatio, props.stackItems, _this.state.draggingItem, _this.state.resizingItem, _this.state.dragTime, _this.state.resizingEdge, _this.state.resizeTime, _this.state.newGroupOrder, _this.state.masterId),
           dimensionItems = _stackTimelineItems.dimensionItems,
           height = _stackTimelineItems.height,
           groupHeights = _stackTimelineItems.groupHeights,
-          groupTops = _stackTimelineItems.groupTops; // this is needed by dragItem since it uses pageY from the drag events
+          groupTops = _stackTimelineItems.groupTops,
+          masterTops = _stackTimelineItems.masterTops; // this is needed by dragItem since it uses pageY from the drag events
       // if this was in the context of the scrollElement, this would not be necessary
 
 
@@ -149,7 +150,8 @@ function (_Component) {
         dimensionItems: dimensionItems,
         height: height,
         groupHeights: groupHeights,
-        groupTops: groupTops
+        groupTops: groupTops,
+        masterTops: masterTops
       });
 
       _this.scrollComponent.scrollLeft = width;
@@ -276,7 +278,7 @@ function (_Component) {
       return time;
     });
 
-    _defineProperty(_assertThisInitialized(_this), "dragItem", function (item, dragTime, newGroupOrder) {
+    _defineProperty(_assertThisInitialized(_this), "dragItem", function (item, dragTime, newGroupOrder, masterId) {
       var newGroup = _this.props.groups[newGroupOrder];
       var keys = _this.props.keys;
 
@@ -284,18 +286,20 @@ function (_Component) {
         draggingItem: item,
         dragTime: dragTime,
         newGroupOrder: newGroupOrder,
-        dragGroupTitle: newGroup ? (0, _generic._get)(newGroup, keys.groupLabelKey) : ''
+        dragGroupTitle: newGroup ? (0, _generic._get)(newGroup, keys.groupLabelKey) : '',
+        masterId: masterId
       });
 
       _this.updatingItem({
         eventType: 'move',
         itemId: item,
         time: dragTime,
-        newGroupOrder: newGroupOrder
+        newGroupOrder: newGroupOrder,
+        masterId: masterId
       });
     });
 
-    _defineProperty(_assertThisInitialized(_this), "dropItem", function (item, dragTime, newGroupOrder) {
+    _defineProperty(_assertThisInitialized(_this), "dropItem", function (item, dragTime, newGroupOrder, masterId) {
       _this.setState({
         draggingItem: null,
         dragTime: null,
@@ -303,7 +307,7 @@ function (_Component) {
       });
 
       if (_this.props.onItemMove) {
-        _this.props.onItemMove(item, dragTime, newGroupOrder);
+        _this.props.onItemMove(item, dragTime, newGroupOrder, masterId);
       }
     });
 
@@ -339,7 +343,8 @@ function (_Component) {
           itemId = _ref.itemId,
           time = _ref.time,
           edge = _ref.edge,
-          newGroupOrder = _ref.newGroupOrder;
+          newGroupOrder = _ref.newGroupOrder,
+          masterId = _ref.masterId;
 
       if (_this.props.onItemDrag) {
         _this.props.onItemDrag({
@@ -347,7 +352,8 @@ function (_Component) {
           itemId: itemId,
           time: time,
           edge: edge,
-          newGroupOrder: newGroupOrder
+          newGroupOrder: newGroupOrder,
+          masterId: masterId
         });
       }
     });
@@ -466,11 +472,12 @@ function (_Component) {
 
     var _canvasWidth = (0, _calendar.getCanvasWidth)(_this.state.width);
 
-    var _stackTimelineItems2 = (0, _calendar.stackTimelineItems)(_props.items, _props.groups, _canvasWidth, _this.state.canvasTimeStart, _this.state.canvasTimeEnd, _props.keys, _props.lineHeight, _props.itemHeightRatio, _props.stackItems, _this.state.draggingItem, _this.state.resizingItem, _this.state.dragTime, _this.state.resizingEdge, _this.state.resizeTime, _this.state.newGroupOrder),
+    var _stackTimelineItems2 = (0, _calendar.stackTimelineItems)(_props.items, _props.groups, _canvasWidth, _this.state.canvasTimeStart, _this.state.canvasTimeEnd, _props.keys, _props.lineHeight, _props.itemHeightRatio, _props.stackItems, _this.state.draggingItem, _this.state.resizingItem, _this.state.dragTime, _this.state.resizingEdge, _this.state.resizeTime, _this.state.newGroupOrder, _this.state.masterId),
         _dimensionItems = _stackTimelineItems2.dimensionItems,
         _height = _stackTimelineItems2.height,
         _groupHeights = _stackTimelineItems2.groupHeights,
-        _groupTops = _stackTimelineItems2.groupTops;
+        _groupTops = _stackTimelineItems2.groupTops,
+        _masterTops = _stackTimelineItems2.masterTops;
     /* eslint-disable react/no-direct-mutation-state */
 
 
@@ -478,6 +485,7 @@ function (_Component) {
     _this.state.height = _height;
     _this.state.groupHeights = _groupHeights;
     _this.state.groupTops = _groupTops;
+    _this.state.masterTops = _masterTops;
     /* eslint-enable */
 
     return _this;
@@ -560,13 +568,14 @@ function (_Component) {
     }
   }, {
     key: "items",
-    value: function items(canvasTimeStart, zoom, canvasTimeEnd, canvasWidth, minUnit, dimensionItems, groupHeights, groupTops) {
+    value: function items(canvasTimeStart, zoom, canvasTimeEnd, canvasWidth, minUnit, dimensionItems, groupHeights, groupTops, masterTops) {
       return _react["default"].createElement(_Items["default"], {
         canvasTimeStart: canvasTimeStart,
         canvasTimeEnd: canvasTimeEnd,
         canvasWidth: canvasWidth,
         dimensionItems: dimensionItems,
         groupTops: groupTops,
+        masterTops: masterTops,
         items: this.props.items,
         groups: this.props.groups,
         keys: this.props.keys,
@@ -625,7 +634,7 @@ function (_Component) {
 
   }, {
     key: "childrenWithProps",
-    value: function childrenWithProps(canvasTimeStart, canvasTimeEnd, canvasWidth, dimensionItems, groupHeights, groupTops, height, visibleTimeStart, visibleTimeEnd, minUnit, timeSteps) {
+    value: function childrenWithProps(canvasTimeStart, canvasTimeEnd, canvasWidth, dimensionItems, groupHeights, groupTops, masterTops, height, visibleTimeStart, visibleTimeEnd, minUnit, timeSteps) {
       var _this3 = this;
 
       if (!this.props.children) {
@@ -648,6 +657,7 @@ function (_Component) {
         keys: this.props.keys,
         groupHeights: groupHeights,
         groupTops: groupTops,
+        masterTops: masterTops,
         selected: this.getSelected(),
         height: height,
         minUnit: minUnit,
@@ -704,18 +714,20 @@ function (_Component) {
           dimensionItems = _this$state6.dimensionItems,
           height = _this$state6.height,
           groupHeights = _this$state6.groupHeights,
-          groupTops = _this$state6.groupTops;
+          groupTops = _this$state6.groupTops,
+          masterTops = _this$state6.masterTops;
       var zoom = visibleTimeEnd - visibleTimeStart;
       var canvasWidth = (0, _calendar.getCanvasWidth)(width);
       var minUnit = (0, _calendar.getMinUnit)(zoom, width, timeSteps);
       var isInteractingWithItem = !!draggingItem || !!resizingItem;
 
       if (isInteractingWithItem) {
-        var stackResults = (0, _calendar.stackTimelineItems)(items, groups, canvasWidth, this.state.canvasTimeStart, this.state.canvasTimeEnd, this.props.keys, this.props.lineHeight, this.props.itemHeightRatio, this.props.stackItems, this.state.draggingItem, this.state.resizingItem, this.state.dragTime, this.state.resizingEdge, this.state.resizeTime, this.state.newGroupOrder);
+        var stackResults = (0, _calendar.stackTimelineItems)(items, groups, canvasWidth, this.state.canvasTimeStart, this.state.canvasTimeEnd, this.props.keys, this.props.lineHeight, this.props.itemHeightRatio, this.props.stackItems, this.state.draggingItem, this.state.resizingItem, this.state.dragTime, this.state.resizingEdge, this.state.resizeTime, this.state.newGroupOrder, this.state.masterId);
         dimensionItems = stackResults.dimensionItems;
         height = stackResults.height;
         groupHeights = stackResults.groupHeights;
         groupTops = stackResults.groupTops;
+        masterTops = stackResults.masterTops;
       }
 
       var outerComponentStyle = {
@@ -753,7 +765,7 @@ function (_Component) {
         traditionalZoom: traditionalZoom,
         onScroll: this.onScroll,
         isInteractingWithItem: isInteractingWithItem
-      }, _react["default"].createElement(_MarkerCanvas["default"], null, this.columns(canvasTimeStart, canvasTimeEnd, canvasWidth, minUnit, timeSteps, height), this.rows(canvasWidth, groupHeights, groups), this.items(canvasTimeStart, zoom, canvasTimeEnd, canvasWidth, minUnit, dimensionItems, groupHeights, groupTops), this.childrenWithProps(canvasTimeStart, canvasTimeEnd, canvasWidth, dimensionItems, groupHeights, groupTops, height, visibleTimeStart, visibleTimeEnd, minUnit, timeSteps))), rightSidebarWidth > 0 ? this.rightSidebar(height, groupHeights) : null)))));
+      }, _react["default"].createElement(_MarkerCanvas["default"], null, this.columns(canvasTimeStart, canvasTimeEnd, canvasWidth, minUnit, timeSteps, height), this.rows(canvasWidth, groupHeights, groups), this.items(canvasTimeStart, zoom, canvasTimeEnd, canvasWidth, minUnit, dimensionItems, groupHeights, groupTops, masterTops), this.childrenWithProps(canvasTimeStart, canvasTimeEnd, canvasWidth, dimensionItems, groupHeights, groupTops, masterTops, height, visibleTimeStart, visibleTimeEnd, minUnit, timeSteps))), rightSidebarWidth > 0 ? this.rightSidebar(height, groupHeights) : null)))));
     }
   }], [{
     key: "getDerivedStateFromProps",
@@ -777,7 +789,7 @@ function (_Component) {
       } else if (forceUpdate) {
         // Calculate new item stack position as canvas may have changed
         var canvasWidth = (0, _calendar.getCanvasWidth)(prevState.width);
-        Object.assign(derivedState, (0, _calendar.stackTimelineItems)(items, groups, canvasWidth, prevState.canvasTimeStart, prevState.canvasTimeEnd, nextProps.keys, nextProps.lineHeight, nextProps.itemHeightRatio, nextProps.stackItems, prevState.draggingItem, prevState.resizingItem, prevState.dragTime, prevState.resizingEdge, prevState.resizeTime, prevState.newGroupOrder));
+        Object.assign(derivedState, (0, _calendar.stackTimelineItems)(items, groups, canvasWidth, prevState.canvasTimeStart, prevState.canvasTimeEnd, nextProps.keys, nextProps.lineHeight, nextProps.itemHeightRatio, nextProps.stackItems, prevState.draggingItem, prevState.resizingItem, prevState.dragTime, prevState.resizingEdge, prevState.resizeTime, prevState.newGroupOrder, prevState.masterId));
       }
 
       return derivedState;

--- a/lib/lib/items/Item.js
+++ b/lib/lib/items/Item.js
@@ -267,10 +267,11 @@ function (_Component) {
         }
 
         var groupDelta = 0;
-        var masterId = masterTops[0].id;
-        var offset = (0, _domHelpers.getSumOffset)(this.props.scrollRef).offsetTop;
+        var masterId = null; // Compute group difference based on groupTops
+
+        var offsetTop = (0, _domHelpers.getSumOffset)(this.props.scrollRef).offsetTop;
         var scrolls = (0, _domHelpers.getSumScroll)(this.props.scrollRef);
-        var topDelta = e.pageY - offset + scrolls.scrollTop;
+        var topDelta = e.pageY - offsetTop + scrolls.scrollTop;
         var groupIndex = 0;
 
         for (groupIndex; groupIndex < groupTops.length; groupIndex++) {
@@ -283,15 +284,26 @@ function (_Component) {
           }
         }
 
-        var masterIndex = 0;
+        var newGroupTop = groupTops[groupIndex - 1]; // Compute master Id 
+        // First filter masters that are aligned on the X axe 
 
-        for (masterIndex; masterIndex < masterTops.length; masterIndex++) {
-          var masterTop = masterTops[masterIndex].dimensions.top;
-          masterId = masterTops[masterIndex].id;
+        var offsetLeft = (0, _domHelpers.getSumOffset)(this.props.scrollRef).offsetLeft;
+        var masterTopsInColumn = masterTops.filter(function (_ref) {
+          var dimensions = _ref.dimensions;
+          return dimensions.left < e.pageX - offsetLeft + scrolls.scrollLeft && dimensions.left + dimensions.width > e.pageX - offsetLeft + scrolls.scrollLeft;
+        }); // Then get closest upper master which is in the correct group
+        // Iterate on each master and check if it is the closest one, else continue
 
-          if ((masterIndex === masterTops.length - 1 || topDelta < masterTops[masterIndex + 1].dimensions.top) && masterTop > groupTops[groupIndex - 1]) {
-            break;
-          }
+        for (var masterIndex = 0; masterIndex < masterTopsInColumn.length; masterIndex++) {
+          var currentlyTestedMasterTop = masterTopsInColumn[masterIndex].dimensions.top;
+          masterId = masterTopsInColumn[masterIndex].id;
+
+          if ((masterIndex === masterTopsInColumn.length - 1 || // It is the last master OR
+          topDelta < masterTopsInColumn[masterIndex + 1].dimensions.top) && // next master top is bigger than cursor
+          currentlyTestedMasterTop > newGroupTop // AND master is in the same group as cursor
+          ) {
+              break;
+            }
         }
 
         if (this.props.order.index + groupDelta < 0) {

--- a/lib/lib/items/Item.js
+++ b/lib/lib/items/Item.js
@@ -285,25 +285,21 @@ function (_Component) {
         }
 
         var newGroupTop = groupTops[groupIndex - 1]; // Compute master Id 
-        // First filter masters that are aligned on the X axe 
+        // First filter masters that are aligned on the X axe and in the same group
 
         var offsetLeft = (0, _domHelpers.getSumOffset)(this.props.scrollRef).offsetLeft;
-        var masterTopsInColumn = masterTops.filter(function (_ref) {
+        var masterTopsInColumnAndGroup = masterTops.filter(function (_ref) {
           var dimensions = _ref.dimensions;
-          return dimensions.left < e.pageX - offsetLeft + scrolls.scrollLeft && dimensions.left + dimensions.width > e.pageX - offsetLeft + scrolls.scrollLeft;
-        }); // Then get closest upper master which is in the correct group
-        // Iterate on each master and check if it is the closest one, else continue
+          return dimensions.left < e.pageX - offsetLeft + scrolls.scrollLeft && dimensions.left + dimensions.width > e.pageX - offsetLeft + scrolls.scrollLeft && dimensions.top > newGroupTop && (groupIndex == groupTops.length || dimensions.top < groupTops[groupIndex]);
+        }); // Then get the closest upper master 
+        // Iterate on each master and check if it is above the closest one, else continue
 
-        for (var masterIndex = 0; masterIndex < masterTopsInColumn.length; masterIndex++) {
-          var currentlyTestedMasterTop = masterTopsInColumn[masterIndex].dimensions.top;
-          masterId = masterTopsInColumn[masterIndex].id;
+        for (var masterIndex = 0; masterIndex < masterTopsInColumnAndGroup.length; masterIndex++) {
+          masterId = masterTopsInColumnAndGroup[masterIndex].id;
 
-          if ((masterIndex === masterTopsInColumn.length - 1 || // It is the last master OR
-          topDelta < masterTopsInColumn[masterIndex + 1].dimensions.top) && // next master top is bigger than cursor
-          currentlyTestedMasterTop > newGroupTop // AND master is in the same group as cursor
-          ) {
-              break;
-            }
+          if (masterIndex == masterTopsInColumnAndGroup.length - 1 || topDelta < masterTopsInColumnAndGroup[masterIndex + 1].dimensions.top) {
+            break;
+          }
         }
 
         if (this.props.order.index + groupDelta < 0) {

--- a/lib/lib/items/Item.js
+++ b/lib/lib/items/Item.js
@@ -172,6 +172,7 @@ function (_Component) {
 
     _this.state = {
       interactMounted: false,
+      masterId: null,
       dragging: null,
       dragStart: null,
       preDragPosition: null,
@@ -188,7 +189,7 @@ function (_Component) {
   _createClass(Item, [{
     key: "shouldComponentUpdate",
     value: function shouldComponentUpdate(nextProps, nextState) {
-      var shouldUpdate = nextState.dragging !== this.state.dragging || nextState.dragTime !== this.state.dragTime || nextState.dragGroupDelta !== this.state.dragGroupDelta || nextState.resizing !== this.state.resizing || nextState.resizeTime !== this.state.resizeTime || nextProps.keys !== this.props.keys || !(0, _generic.deepObjectCompare)(nextProps.itemProps, this.props.itemProps) || nextProps.selected !== this.props.selected || nextProps.item !== this.props.item || nextProps.canvasTimeStart !== this.props.canvasTimeStart || nextProps.canvasTimeEnd !== this.props.canvasTimeEnd || nextProps.canvasWidth !== this.props.canvasWidth || (nextProps.order ? nextProps.order.index : undefined) !== (this.props.order ? this.props.order.index : undefined) || nextProps.dragSnap !== this.props.dragSnap || nextProps.minResizeWidth !== this.props.minResizeWidth || nextProps.canChangeGroup !== this.props.canChangeGroup || nextProps.canSelect !== this.props.canSelect || nextProps.canMove !== this.props.canMove || nextProps.canResizeLeft !== this.props.canResizeLeft || nextProps.canResizeRight !== this.props.canResizeRight || nextProps.dimensions !== this.props.dimensions;
+      var shouldUpdate = nextState.dragging !== this.state.dragging || nextState.dragTime !== this.state.dragTime || nextState.dragGroupDelta !== this.state.dragGroupDelta || nextState.masterId !== this.state.masterId || nextState.resizing !== this.state.resizing || nextState.resizeTime !== this.state.resizeTime || nextProps.keys !== this.props.keys || !(0, _generic.deepObjectCompare)(nextProps.itemProps, this.props.itemProps) || nextProps.selected !== this.props.selected || nextProps.item !== this.props.item || nextProps.canvasTimeStart !== this.props.canvasTimeStart || nextProps.canvasTimeEnd !== this.props.canvasTimeEnd || nextProps.canvasWidth !== this.props.canvasWidth || (nextProps.order ? nextProps.order.index : undefined) !== (this.props.order ? this.props.order.index : undefined) || nextProps.dragSnap !== this.props.dragSnap || nextProps.minResizeWidth !== this.props.minResizeWidth || nextProps.canChangeGroup !== this.props.canChangeGroup || nextProps.canSelect !== this.props.canSelect || nextProps.canMove !== this.props.canMove || nextProps.canResizeLeft !== this.props.canResizeLeft || nextProps.canResizeRight !== this.props.canResizeRight || nextProps.dimensions !== this.props.dimensions;
       return shouldUpdate;
     }
   }, {
@@ -253,11 +254,12 @@ function (_Component) {
       return (e.pageX - offset + scrolls.scrollLeft) * ratio + this.props.canvasTimeStart;
     }
   }, {
-    key: "dragGroupDelta",
-    value: function dragGroupDelta(e) {
+    key: "dragGroupDeltaAndMasterId",
+    value: function dragGroupDeltaAndMasterId(e) {
       var _this$props2 = this.props,
           groupTops = _this$props2.groupTops,
-          order = _this$props2.order;
+          order = _this$props2.order,
+          masterTops = _this$props2.masterTops;
 
       if (this.state.dragging) {
         if (!this.props.canChangeGroup) {
@@ -265,27 +267,49 @@ function (_Component) {
         }
 
         var groupDelta = 0;
+        var masterId = masterTops[0].id;
         var offset = (0, _domHelpers.getSumOffset)(this.props.scrollRef).offsetTop;
         var scrolls = (0, _domHelpers.getSumScroll)(this.props.scrollRef);
+        var topDelta = e.pageY - offset + scrolls.scrollTop;
+        var groupIndex = 0;
 
-        for (var _i = 0, _Object$keys = Object.keys(groupTops); _i < _Object$keys.length; _i++) {
-          var key = _Object$keys[_i];
-          var groupTop = groupTops[key];
+        for (groupIndex; groupIndex < groupTops.length; groupIndex++) {
+          var groupTop = groupTops[groupIndex];
 
-          if (e.pageY - offset + scrolls.scrollTop > groupTop) {
-            groupDelta = parseInt(key, 10) - order.index;
+          if (topDelta > groupTop) {
+            groupDelta = groupIndex - order.index;
           } else {
             break;
           }
         }
 
+        var masterIndex = 0;
+
+        for (masterIndex; masterIndex < masterTops.length; masterIndex++) {
+          var masterTop = masterTops[masterIndex].dimensions.top;
+          masterId = masterTops[masterIndex].id;
+
+          if ((masterIndex === masterTops.length - 1 || topDelta < masterTops[masterIndex + 1].dimensions.top) && masterTop > groupTops[groupIndex - 1]) {
+            break;
+          }
+        }
+
         if (this.props.order.index + groupDelta < 0) {
-          return 0 - this.props.order.index;
+          return {
+            groupDelta: 0 - this.props.order.index,
+            masterId: masterId
+          };
         } else {
-          return groupDelta;
+          return {
+            groupDelta: groupDelta,
+            masterId: masterId
+          };
         }
       } else {
-        return 0;
+        return {
+          groupDelta: 0,
+          masterId: 0
+        };
       }
     }
   }, {
@@ -337,7 +361,8 @@ function (_Component) {
               y: e.target.offsetTop
             },
             dragTime: _this2.itemTimeStart,
-            dragGroupDelta: 0
+            dragGroupDelta: 0,
+            masterId: null
           });
         } else {
           return false;
@@ -346,19 +371,22 @@ function (_Component) {
         if (_this2.state.dragging) {
           var dragTime = _this2.dragTime(e);
 
-          var dragGroupDelta = _this2.dragGroupDelta(e);
+          var _this2$dragGroupDelta = _this2.dragGroupDeltaAndMasterId(e),
+              groupDelta = _this2$dragGroupDelta.groupDelta,
+              masterId = _this2$dragGroupDelta.masterId;
 
           if (_this2.props.moveResizeValidator) {
             dragTime = _this2.props.moveResizeValidator('move', _this2.props.item, dragTime);
           }
 
           if (_this2.props.onDrag) {
-            _this2.props.onDrag(_this2.itemId, dragTime, _this2.props.order.index + dragGroupDelta);
+            _this2.props.onDrag(_this2.itemId, dragTime, _this2.props.order.index + groupDelta, masterId);
           }
 
           _this2.setState({
             dragTime: dragTime,
-            dragGroupDelta: dragGroupDelta
+            dragGroupDelta: groupDelta,
+            masterId: masterId
           });
         }
       }).on('dragend', function (e) {
@@ -370,7 +398,11 @@ function (_Component) {
               dragTime = _this2.props.moveResizeValidator('move', _this2.props.item, dragTime);
             }
 
-            _this2.props.onDrop(_this2.itemId, dragTime, _this2.props.order.index + _this2.dragGroupDelta(e));
+            var _this2$dragGroupDelta2 = _this2.dragGroupDeltaAndMasterId(e),
+                groupDelta = _this2$dragGroupDelta2.groupDelta,
+                masterId = _this2$dragGroupDelta2.masterId;
+
+            _this2.props.onDrop(_this2.itemId, dragTime, _this2.props.order.index + groupDelta, masterId);
           }
 
           _this2.setState({
@@ -378,7 +410,8 @@ function (_Component) {
             dragStart: null,
             preDragPosition: null,
             dragTime: null,
-            dragGroupDelta: null
+            dragGroupDelta: null,
+            masterId: null
           });
         }
       }).on('resizestart', function (e) {
@@ -565,6 +598,7 @@ function (_Component) {
         dragStart: this.state.dragStart,
         dragTime: this.state.dragTime,
         dragGroupDelta: this.state.dragGroupDelta,
+        masterId: this.state.masterId,
         resizing: this.state.resizing,
         resizeEdge: this.state.resizeEdge,
         resizeStart: this.state.resizeStart,
@@ -611,6 +645,7 @@ _defineProperty(Item, "propTypes", {
   canSelect: _propTypes["default"].bool,
   dimensions: _propTypes["default"].object,
   groupTops: _propTypes["default"].array,
+  masterTops: _propTypes["default"].array,
   useResizeHandle: _propTypes["default"].bool,
   moveResizeValidator: _propTypes["default"].func,
   onItemDoubleClick: _propTypes["default"].func,

--- a/lib/lib/items/Items.js
+++ b/lib/lib/items/Items.js
@@ -118,6 +118,7 @@ function (_Component) {
           canSelect: (0, _generic._get)(item, 'canSelect') !== undefined ? (0, _generic._get)(item, 'canSelect') : _this.props.canSelect,
           useResizeHandle: _this.props.useResizeHandle,
           groupTops: _this.props.groupTops,
+          masterTops: _this.props.masterTops,
           canvasTimeStart: _this.props.canvasTimeStart,
           canvasTimeEnd: _this.props.canvasTimeEnd,
           canvasWidth: _this.props.canvasWidth,
@@ -169,6 +170,7 @@ _defineProperty(Items, "propTypes", {
   selected: _propTypes["default"].array,
   dimensionItems: _propTypes["default"].array,
   groupTops: _propTypes["default"].array,
+  masterTops: _propTypes["default"].array,
   useResizeHandle: _propTypes["default"].bool,
   scrollRef: _propTypes["default"].object
 });

--- a/lib/lib/utility/calendar.js
+++ b/lib/lib/utility/calendar.js
@@ -382,6 +382,7 @@ function sum() {
 function stackAll(itemsDimensions, groupOrders, lineHeight, stackItems) {
   var groupHeights = [];
   var groupTops = [];
+  var masterTops = [];
   var groupedItems = getGroupedItems(itemsDimensions, groupOrders);
 
   for (var index in groupedItems) {
@@ -408,10 +409,17 @@ function stackAll(itemsDimensions, groupOrders, lineHeight, stackItems) {
     }
   }
 
+  masterTops = itemsDimensions.filter(function (_ref3) {
+    var isMaster = _ref3.isMaster;
+    return isMaster;
+  }).sort(function (a, b) {
+    return a.dimensions.top - b.dimensions.top;
+  });
   return {
     height: sum(groupHeights),
     groupHeights: groupHeights,
-    groupTops: groupTops
+    groupTops: groupTops,
+    masterTops: masterTops
   };
 }
 /**
@@ -464,10 +472,11 @@ function stackGroup(itemsDimensions, isGroupStacked, shouldStackEnforceOrder, li
  * @param {left or right} resizingEdge
  * @param {number} resizeTime
  * @param {number} newGroupOrder
+ * @param {number} masterId
  */
 
 
-function stackTimelineItems(items, groups, canvasWidth, canvasTimeStart, canvasTimeEnd, keys, lineHeight, itemHeightRatio, stackItems, draggingItem, resizingItem, dragTime, resizingEdge, resizeTime, newGroupOrder) {
+function stackTimelineItems(items, groups, canvasWidth, canvasTimeStart, canvasTimeEnd, keys, lineHeight, itemHeightRatio, stackItems, draggingItem, resizingItem, dragTime, resizingEdge, resizeTime, newGroupOrder, masterId) {
   var visibleItems = getVisibleItems(items, canvasTimeStart, canvasTimeEnd, keys);
   var visibleItemsWithInteraction = visibleItems.map(function (item) {
     return getItemWithInteractions({
@@ -481,21 +490,39 @@ function stackTimelineItems(items, groups, canvasWidth, canvasTimeStart, canvasT
       groups: groups,
       newGroupOrder: newGroupOrder
     });
-  }); // if there are no groups return an empty array of dimensions
+  }); // Reorder dragged item 
+
+  var draggedItemIndex = visibleItemsWithInteraction.findIndex(function (item) {
+    return (0, _generic._get)(item, keys.itemIdKey) === draggingItem;
+  });
+
+  if (draggedItemIndex > 0) {
+    var _visibleItemsWithInte = visibleItemsWithInteraction.splice(draggedItemIndex, 1),
+        _visibleItemsWithInte2 = _slicedToArray(_visibleItemsWithInte, 1),
+        draggedItem = _visibleItemsWithInte2[0];
+
+    var masterIndex = visibleItemsWithInteraction.findIndex(function (_ref4) {
+      var id = _ref4.id;
+      return id === masterId;
+    });
+    visibleItemsWithInteraction.splice(masterIndex + 1, 0, draggedItem);
+  } // if there are no groups return an empty array of dimensions
+
 
   if (groups.length === 0) {
     return {
       dimensionItems: [],
       height: 0,
       groupHeights: [],
-      groupTops: []
+      groupTops: [],
+      masterTops: []
     };
   } // Get the order of groups based on their id key
 
 
   var groupOrders = getGroupOrders(groups, keys);
   var dimensionItems = visibleItemsWithInteraction.map(function (item) {
-    return getItemDimensions({
+    return _objectSpread({}, getItemDimensions({
       item: item,
       keys: keys,
       canvasTimeStart: canvasTimeStart,
@@ -504,6 +531,8 @@ function stackTimelineItems(items, groups, canvasWidth, canvasTimeStart, canvasT
       groupOrders: groupOrders,
       lineHeight: lineHeight,
       itemHeightRatio: itemHeightRatio
+    }), {
+      isMaster: item.isMaster
     });
   }).filter(function (item) {
     return !!item;
@@ -512,13 +541,15 @@ function stackTimelineItems(items, groups, canvasWidth, canvasTimeStart, canvasT
   var _stackAll = stackAll(dimensionItems, groupOrders, lineHeight, stackItems),
       height = _stackAll.height,
       groupHeights = _stackAll.groupHeights,
-      groupTops = _stackAll.groupTops;
+      groupTops = _stackAll.groupTops,
+      masterTops = _stackAll.masterTops;
 
   return {
     dimensionItems: dimensionItems,
     height: height,
     groupHeights: groupHeights,
-    groupTops: groupTops
+    groupTops: groupTops,
+    masterTops: masterTops
   };
 }
 /**
@@ -545,15 +576,15 @@ function getCanvasWidth(width) {
  */
 
 
-function getItemDimensions(_ref3) {
-  var item = _ref3.item,
-      keys = _ref3.keys,
-      canvasTimeStart = _ref3.canvasTimeStart,
-      canvasTimeEnd = _ref3.canvasTimeEnd,
-      canvasWidth = _ref3.canvasWidth,
-      groupOrders = _ref3.groupOrders,
-      lineHeight = _ref3.lineHeight,
-      itemHeightRatio = _ref3.itemHeightRatio;
+function getItemDimensions(_ref5) {
+  var item = _ref5.item,
+      keys = _ref5.keys,
+      canvasTimeStart = _ref5.canvasTimeStart,
+      canvasTimeEnd = _ref5.canvasTimeEnd,
+      canvasWidth = _ref5.canvasWidth,
+      groupOrders = _ref5.groupOrders,
+      lineHeight = _ref5.lineHeight,
+      itemHeightRatio = _ref5.itemHeightRatio;
   var itemId = (0, _generic._get)(item, keys.itemIdKey);
   var dimension = calculateDimensions({
     itemTimeStart: (0, _generic._get)(item, keys.itemTimeStartKey),
@@ -589,18 +620,18 @@ function getItemDimensions(_ref3) {
  */
 
 
-function getItemWithInteractions(_ref4) {
+function getItemWithInteractions(_ref6) {
   var _objectSpread2;
 
-  var item = _ref4.item,
-      keys = _ref4.keys,
-      draggingItem = _ref4.draggingItem,
-      resizingItem = _ref4.resizingItem,
-      dragTime = _ref4.dragTime,
-      resizingEdge = _ref4.resizingEdge,
-      resizeTime = _ref4.resizeTime,
-      groups = _ref4.groups,
-      newGroupOrder = _ref4.newGroupOrder;
+  var item = _ref6.item,
+      keys = _ref6.keys,
+      draggingItem = _ref6.draggingItem,
+      resizingItem = _ref6.resizingItem,
+      dragTime = _ref6.dragTime,
+      resizingEdge = _ref6.resizingEdge,
+      resizeTime = _ref6.resizeTime,
+      groups = _ref6.groups,
+      newGroupOrder = _ref6.newGroupOrder;
   if (!resizingItem && !draggingItem) return item;
   var itemId = (0, _generic._get)(item, keys.itemIdKey);
   var isDragging = itemId === draggingItem;

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -17,7 +17,7 @@ import {
   calculateScrollCanvas,
   getCanvasBoundariesFromVisibleTime,
   getCanvasWidth,
-  stackTimelineItems
+  stackTimelineItems,
 } from './utility/calendar'
 import { _get, _length } from './utility/generic'
 import {
@@ -329,7 +329,8 @@ export default class ReactCalendarTimeline extends Component {
       dimensionItems,
       height,
       groupHeights,
-      groupTops
+      groupTops,
+      masterTops
     } = stackTimelineItems(
       props.items,
       props.groups,
@@ -345,7 +346,8 @@ export default class ReactCalendarTimeline extends Component {
       this.state.dragTime,
       this.state.resizingEdge,
       this.state.resizeTime,
-      this.state.newGroupOrder
+      this.state.newGroupOrder,
+      this.state.masterId
     )
 
     /* eslint-disable react/no-direct-mutation-state */
@@ -353,6 +355,7 @@ export default class ReactCalendarTimeline extends Component {
     this.state.height = height
     this.state.groupHeights = groupHeights
     this.state.groupTops = groupTops
+    this.state.masterTops = masterTops
 
     /* eslint-enable */
   }
@@ -422,7 +425,8 @@ export default class ReactCalendarTimeline extends Component {
           prevState.dragTime,
           prevState.resizingEdge,
           prevState.resizeTime,
-          prevState.newGroupOrder
+          prevState.newGroupOrder,
+          prevState.masterId,
         )
       )
     }
@@ -476,7 +480,8 @@ export default class ReactCalendarTimeline extends Component {
       dimensionItems,
       height,
       groupHeights,
-      groupTops
+      groupTops,
+      masterTops
     } = stackTimelineItems(
       props.items,
       props.groups,
@@ -492,7 +497,8 @@ export default class ReactCalendarTimeline extends Component {
       this.state.dragTime,
       this.state.resizingEdge,
       this.state.resizeTime,
-      this.state.newGroupOrder
+      this.state.newGroupOrder,
+      this.state.masterId,
     )
 
     // this is needed by dragItem since it uses pageY from the drag events
@@ -503,7 +509,8 @@ export default class ReactCalendarTimeline extends Component {
       dimensionItems,
       height,
       groupHeights,
-      groupTops
+      groupTops,
+      masterTops
     })
 
     this.scrollComponent.scrollLeft = width
@@ -669,7 +676,7 @@ export default class ReactCalendarTimeline extends Component {
     return time
   }
 
-  dragItem = (item, dragTime, newGroupOrder) => {
+  dragItem = (item, dragTime, newGroupOrder, masterId) => {
     let newGroup = this.props.groups[newGroupOrder]
     const keys = this.props.keys
 
@@ -677,21 +684,23 @@ export default class ReactCalendarTimeline extends Component {
       draggingItem: item,
       dragTime: dragTime,
       newGroupOrder: newGroupOrder,
-      dragGroupTitle: newGroup ? _get(newGroup, keys.groupLabelKey) : ''
+      dragGroupTitle: newGroup ? _get(newGroup, keys.groupLabelKey) : '',
+      masterId: masterId
     })
 
     this.updatingItem({
       eventType: 'move',
       itemId: item,
       time: dragTime,
-      newGroupOrder
+      newGroupOrder,
+      masterId
     })
   }
 
-  dropItem = (item, dragTime, newGroupOrder) => {
+  dropItem = (item, dragTime, newGroupOrder, masterId) => {
     this.setState({ draggingItem: null, dragTime: null, dragGroupTitle: null })
     if (this.props.onItemMove) {
-      this.props.onItemMove(item, dragTime, newGroupOrder)
+      this.props.onItemMove(item, dragTime, newGroupOrder, masterId)
     }
   }
 
@@ -717,9 +726,9 @@ export default class ReactCalendarTimeline extends Component {
     }
   }
 
-  updatingItem = ({ eventType, itemId, time, edge, newGroupOrder }) => {
+  updatingItem = ({ eventType, itemId, time, edge, newGroupOrder, masterId }) => {
     if (this.props.onItemDrag) {
-      this.props.onItemDrag({ eventType, itemId, time, edge, newGroupOrder })
+      this.props.onItemDrag({ eventType, itemId, time, edge, newGroupOrder, masterId })
     }
   }
 
@@ -814,7 +823,8 @@ export default class ReactCalendarTimeline extends Component {
     minUnit,
     dimensionItems,
     groupHeights,
-    groupTops
+    groupTops,
+    masterTops
   ) {
     return (
       <Items
@@ -823,6 +833,7 @@ export default class ReactCalendarTimeline extends Component {
         canvasWidth={canvasWidth}
         dimensionItems={dimensionItems}
         groupTops={groupTops}
+        masterTops={masterTops}
         items={this.props.items}
         groups={this.props.groups}
         keys={this.props.keys}
@@ -903,6 +914,7 @@ export default class ReactCalendarTimeline extends Component {
     dimensionItems,
     groupHeights,
     groupTops,
+    masterTops,
     height,
     visibleTimeStart,
     visibleTimeEnd,
@@ -930,6 +942,7 @@ export default class ReactCalendarTimeline extends Component {
       keys: this.props.keys,
       groupHeights: groupHeights,
       groupTops: groupTops,
+      masterTops: masterTops,
       selected: this.getSelected(),
       height: height,
       minUnit: minUnit,
@@ -1003,7 +1016,7 @@ export default class ReactCalendarTimeline extends Component {
       canvasTimeStart,
       canvasTimeEnd
     } = this.state
-    let { dimensionItems, height, groupHeights, groupTops } = this.state
+    let { dimensionItems, height, groupHeights, groupTops, masterTops } = this.state
 
     const zoom = visibleTimeEnd - visibleTimeStart
     const canvasWidth = getCanvasWidth(width)
@@ -1027,12 +1040,14 @@ export default class ReactCalendarTimeline extends Component {
         this.state.dragTime,
         this.state.resizingEdge,
         this.state.resizeTime,
-        this.state.newGroupOrder
+        this.state.newGroupOrder,
+        this.state.masterId
       )
       dimensionItems = stackResults.dimensionItems
       height = stackResults.height
       groupHeights = stackResults.groupHeights
       groupTops = stackResults.groupTops
+      masterTops = stackResults.masterTops
     }
 
     const outerComponentStyle = {
@@ -1093,7 +1108,8 @@ export default class ReactCalendarTimeline extends Component {
                       minUnit,
                       dimensionItems,
                       groupHeights,
-                      groupTops
+                      groupTops,
+                      masterTops
                     )}
                     {this.childrenWithProps(
                       canvasTimeStart,
@@ -1102,6 +1118,7 @@ export default class ReactCalendarTimeline extends Component {
                       dimensionItems,
                       groupHeights,
                       groupTops,
+                      masterTops,
                       height,
                       visibleTimeStart,
                       visibleTimeEnd,

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -199,25 +199,24 @@ export default class Item extends Component {
       const newGroupTop = groupTops[groupIndex-1];
 
       // Compute master Id 
-      // First filter masters that are aligned on the X axe 
+      // First filter masters that are aligned on the X axe and in the same group
       const offsetLeft = getSumOffset(this.props.scrollRef).offsetLeft
-      const masterTopsInColumn = masterTops.filter(
+      const masterTopsInColumnAndGroup = masterTops.filter(
         ({dimensions}) => 
           dimensions.left < (e.pageX - offsetLeft + scrolls.scrollLeft) && 
-          dimensions.left + dimensions.width > (e.pageX - offsetLeft + scrolls.scrollLeft)
+          dimensions.left + dimensions.width > (e.pageX - offsetLeft + scrolls.scrollLeft) &&
+          dimensions.top > newGroupTop && 
+          (groupIndex== groupTops.length || dimensions.top < groupTops[groupIndex])
         )
-      // Then get closest upper master which is in the correct group
-      // Iterate on each master and check if it is the closest one, else continue
-      for (let masterIndex=0; masterIndex<masterTopsInColumn.length; masterIndex++) {
-        const currentlyTestedMasterTop = masterTopsInColumn[masterIndex].dimensions.top;
-        masterId = masterTopsInColumn[masterIndex].id;
-        if (
-          (masterIndex === masterTopsInColumn.length-1 || // It is the last master OR
-             topDelta < masterTopsInColumn[masterIndex + 1].dimensions.top) // next master top is bigger than cursor
-          && currentlyTestedMasterTop > newGroupTop // AND master is in the same group as cursor
-          ) {
+      
+      // Then get the closest upper master 
+      // Iterate on each master and check if it is above the closest one, else continue
+      for (let masterIndex=0; masterIndex<masterTopsInColumnAndGroup.length; masterIndex++) {
+        masterId = masterTopsInColumnAndGroup[masterIndex].id;
+        if (masterIndex == masterTopsInColumnAndGroup.length-1 ||
+          topDelta < masterTopsInColumnAndGroup[masterIndex+1].dimensions.top) {
           break
-        }  
+        }
       }
 
       if (this.props.order.index + groupDelta < 0) {

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -53,6 +53,7 @@ export default class Item extends Component {
     canSelect: PropTypes.bool,
     dimensions: PropTypes.object,
     groupTops: PropTypes.array,
+    masterTops: PropTypes.array,
     useResizeHandle: PropTypes.bool,
     moveResizeValidator: PropTypes.func,
     onItemDoubleClick: PropTypes.func,
@@ -76,6 +77,7 @@ export default class Item extends Component {
 
     this.state = {
       interactMounted: false,
+      masterId: null,
 
       dragging: null,
       dragStart: null,
@@ -95,6 +97,7 @@ export default class Item extends Component {
       nextState.dragging !== this.state.dragging ||
       nextState.dragTime !== this.state.dragTime ||
       nextState.dragGroupDelta !== this.state.dragGroupDelta ||
+      nextState.masterId !== this.state.masterId ||
       nextState.resizing !== this.state.resizing ||
       nextState.resizeTime !== this.state.resizeTime ||
       nextProps.keys !== this.props.keys ||
@@ -171,33 +174,44 @@ export default class Item extends Component {
     return (e.pageX - offset + scrolls.scrollLeft) * ratio + this.props.canvasTimeStart;
   }
 
-  dragGroupDelta(e) {
-    const { groupTops, order } = this.props
+  dragGroupDeltaAndMasterId(e) {
+    const { groupTops, order, masterTops } = this.props
     if (this.state.dragging) {
       if (!this.props.canChangeGroup) {
         return 0
       }
       let groupDelta = 0
+      let masterId = masterTops[0].id
 
       const offset = getSumOffset(this.props.scrollRef).offsetTop
       const scrolls = getSumScroll(this.props.scrollRef)
-      
-      for (var key of Object.keys(groupTops)) {
-        var groupTop = groupTops[key]
-        if (e.pageY - offset + scrolls.scrollTop > groupTop) {
-          groupDelta = parseInt(key, 10) - order.index
+      var topDelta = e.pageY - offset + scrolls.scrollTop 
+      let groupIndex=0;
+      for (groupIndex; groupIndex<groupTops.length; groupIndex++) {
+        var groupTop = groupTops[groupIndex]
+        if (topDelta > groupTop) {
+          groupDelta = groupIndex - order.index
         } else {
           break
         }
       }
 
+      let masterIndex=0
+      for (masterIndex; masterIndex<masterTops.length; masterIndex++) {
+        var masterTop = masterTops[masterIndex].dimensions.top
+        masterId = masterTops[masterIndex].id;
+        if ((masterIndex === masterTops.length-1 || topDelta < masterTops[masterIndex + 1].dimensions.top) && masterTop > groupTops[groupIndex-1]) {
+          break
+        }  
+      }
+
       if (this.props.order.index + groupDelta < 0) {
-        return 0 - this.props.order.index
+        return {groupDelta: 0 - this.props.order.index, masterId}
       } else {
-        return groupDelta
+        return {groupDelta, masterId}
       }
     } else {
-      return 0
+      return {groupDelta: 0, masterId: 0}
     }
   }
 
@@ -251,7 +265,8 @@ export default class Item extends Component {
             offset: this.itemTimeStart - clickTime },
             preDragPosition: { x: e.target.offsetLeft, y: e.target.offsetTop },
             dragTime: this.itemTimeStart,
-            dragGroupDelta: 0
+            dragGroupDelta: 0,
+            masterId: null
           })
         } else {
           return false
@@ -260,7 +275,7 @@ export default class Item extends Component {
       .on('dragmove', e => {
         if (this.state.dragging) {
           let dragTime = this.dragTime(e)
-          let dragGroupDelta = this.dragGroupDelta(e)
+          let {groupDelta, masterId} = this.dragGroupDeltaAndMasterId(e)
           if (this.props.moveResizeValidator) {
             dragTime = this.props.moveResizeValidator(
               'move',
@@ -273,13 +288,15 @@ export default class Item extends Component {
             this.props.onDrag(
               this.itemId,
               dragTime,
-              this.props.order.index + dragGroupDelta
+              this.props.order.index + groupDelta,
+              masterId,
             )
           }
 
           this.setState({
             dragTime: dragTime,
-            dragGroupDelta: dragGroupDelta
+            dragGroupDelta: groupDelta,
+            masterId
           })
         }
       })
@@ -295,11 +312,13 @@ export default class Item extends Component {
                 dragTime
               )
             }
+            let {groupDelta, masterId} = this.dragGroupDeltaAndMasterId(e)
 
             this.props.onDrop(
               this.itemId,
               dragTime,
-              this.props.order.index + this.dragGroupDelta(e)
+              this.props.order.index + groupDelta,
+              masterId
             )
           }
 
@@ -308,7 +327,8 @@ export default class Item extends Component {
             dragStart: null,
             preDragPosition: null,
             dragTime: null,
-            dragGroupDelta: null
+            dragGroupDelta: null,
+            masterId: null
           })
         }
       })
@@ -615,6 +635,7 @@ export default class Item extends Component {
       dragStart: this.state.dragStart,
       dragTime: this.state.dragTime,
       dragGroupDelta: this.state.dragGroupDelta,
+      masterId: this.state.masterId,
       resizing: this.state.resizing,
       resizeEdge: this.state.resizeEdge,
       resizeStart: this.state.resizeStart,

--- a/src/lib/items/Items.js
+++ b/src/lib/items/Items.js
@@ -53,6 +53,7 @@ export default class Items extends Component {
 
     dimensionItems: PropTypes.array,
     groupTops: PropTypes.array,
+    masterTops: PropTypes.array,
     useResizeHandle: PropTypes.bool,
     scrollRef: PropTypes.object
   }
@@ -147,6 +148,7 @@ export default class Items extends Component {
               }
               useResizeHandle={this.props.useResizeHandle}
               groupTops={this.props.groupTops}
+              masterTops={this.props.masterTops}
               canvasTimeStart={this.props.canvasTimeStart}
               canvasTimeEnd={this.props.canvasTimeEnd}
               canvasWidth={this.props.canvasWidth}


### PR DESCRIPTION
A new feature is needed to enhance drag & drop on the timeline: the ability to drag and drop items in relation with another item. 
Example : "dragging a booking to a specific shift"

The method used to deal with this is based on the management of "Groups" (=rows) 
1) some items are appointed "masters" through the item attribute `isMaster`
2) items now receive a list of masters positions (`masterTops`)
3) on drag
 3.1) a small computation based on cursor position and masters positions allows to retrieve the closest master, which is returned as `masterId`
 3.2) timeline items list is reordered to put the dragged item just next to its master
 3.3) timeline items are rerendered (re-positioned/stacked) based on their order in this list and their new group (=row)
