### PR TITLE
[Bug] glitchtip 52287

### DIFF
--- a/lib/lib/Timeline.js
+++ b/lib/lib/Timeline.js
@@ -127,6 +127,7 @@ function (_Component) {
 
     _defineProperty(_assertThisInitialized(_this), "resize", function () {
       var props = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.props;
+      if (!_this.container) return;
 
       var _this$container$getBo = _this.container.getBoundingClientRect(),
           containerWidth = _this$container$getBo.width;

--- a/src/lib/Timeline.js
+++ b/src/lib/Timeline.js
@@ -471,6 +471,7 @@ export default class ReactCalendarTimeline extends Component {
   }
 
   resize = (props = this.props) => {
+    if (!this.container) return;
     const { width: containerWidth } = this.container.getBoundingClientRect()
 
     let width = containerWidth - props.sidebarWidth - props.rightSidebarWidth


### PR DESCRIPTION
https://glitchtip.tech.padam.io/padam-mobility/issues/52287?project=131

Reproduce : operate page, click on a shift with bookings, reload the page. The bug doesn't appear each time but around twice out of three when I tested. 

I don't know exactly the root cause but this fix avoids it and still resize the timeline on navbar toggling (aim of resizeDetector) so it does the job..