### PR TITLE
Return full item on item move

### DIFF
--- a/lib/lib/items/Item.js
+++ b/lib/lib/items/Item.js
@@ -408,7 +408,7 @@ function (_Component) {
                 groupDelta = _this2$dragGroupDelta2.groupDelta,
                 masterId = _this2$dragGroupDelta2.masterId;
 
-            _this2.props.onDrop(_this2.itemId, dragTime, _this2.props.order.index + groupDelta, masterId);
+            _this2.props.onDrop(_this2.props.item, dragTime, _this2.props.order.index + groupDelta, masterId);
           }
 
           _this2.setState({

--- a/src/lib/items/Item.js
+++ b/src/lib/items/Item.js
@@ -328,7 +328,7 @@ export default class Item extends Component {
             let {groupDelta, masterId} = this.dragGroupDeltaAndMasterId(e)
 
             this.props.onDrop(
-              this.itemId,
+              this.props.item,
               dragTime,
               this.props.order.index + groupDelta,
               masterId


### PR DESCRIPTION
We had to search again among our initial data to retrieve the item details based on the item ID. It's easier to retrieve directly the item